### PR TITLE
move allianceutil to evergreen package location

### DIFF
--- a/src/main/java/frc/robot/brownbox/util/AllianceUtil.java
+++ b/src/main/java/frc/robot/brownbox/util/AllianceUtil.java
@@ -1,4 +1,4 @@
-package frc.robot.util;
+package frc.robot.brownbox.util;
 
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.DriverStation.Alliance;

--- a/src/main/java/frc/robot/operation/JasonDriverConfiguration.java
+++ b/src/main/java/frc/robot/operation/JasonDriverConfiguration.java
@@ -5,7 +5,7 @@ import edu.wpi.first.wpilibj2.command.button.CommandGenericHID;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import frc.robot.Constants;
 import frc.robot.RobotContainer;
-import frc.robot.util.AllianceUtil;
+import frc.robot.brownbox.util.AllianceUtil;
 
 public class JasonDriverConfiguration extends AbstractCommandXboxOperationConfiguration {
 


### PR DESCRIPTION
Evergreen classes should be under `frc.robot.brownbox.*`, moving `AllianceUtil` there.